### PR TITLE
Upgrade spring-websocket-chat example to Spring Boot 1.2.4.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 buildscript {
     ext {
-        springBootVersion = '1.2.1.RELEASE'
+        springBootVersion = '1.2.4.RELEASE'
     }
     repositories {
         mavenCentral()
@@ -27,9 +27,9 @@ repositories {
 }
 
 ext {
-    commonsPoolVersion = '2.3'
-	redisVersion = '0.3'
-	springSessionVersion = '1.0.0.RELEASE'
+    commonsPoolVersion = '2.4.1'
+	redisVersion = '0.5'
+	springSessionVersion = '1.0.1.RELEASE'
 }
 
 dependencies {
@@ -58,7 +58,7 @@ configurations.all {
     resolutionStrategy {
         eachDependency { DependencyResolveDetails details ->
             if (details.requested.group == "org.springframework.security") {
-                details.useVersion "4.0.0.RC1"
+                details.useVersion "4.0.1.RELEASE"
             }
         }
     }

--- a/src/main/java/com/sergialmar/wschat/Application.java
+++ b/src/main/java/com/sergialmar/wschat/Application.java
@@ -5,8 +5,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class Application {
-	
+
 	public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
-    }
+		SpringApplication.run(Application.class, args);
+	}
 }

--- a/src/main/java/com/sergialmar/wschat/config/ChatConfig.java
+++ b/src/main/java/com/sergialmar/wschat/config/ChatConfig.java
@@ -3,15 +3,12 @@ package com.sergialmar.wschat.config;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Executors;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Description;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
-import org.springframework.context.event.ApplicationEventMulticaster;
-import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import com.sergialmar.wschat.domain.SessionProfanity;
@@ -21,25 +18,27 @@ import com.sergialmar.wschat.util.ProfanityChecker;
 
 @Configuration
 public class ChatConfig {
-	
+
 	public static class Destinations {
-		private Destinations() {}
-		
-		private static final String LOGIN  = "/topic/chat.login";
+		private Destinations() {
+		}
+
+		private static final String LOGIN = "/topic/chat.login";
 		private static final String LOGOUT = "/topic/chat.logout";
 	}
-	
+
 	private static final int MAX_PROFANITY_LEVEL = 5;
-	
+
 	/*
-	@Bean
-	@Description("Application event multicaster to process events asynchonously")
-	public ApplicationEventMulticaster applicationEventMulticaster() {
-		SimpleApplicationEventMulticaster multicaster = new SimpleApplicationEventMulticaster();
-		multicaster.setTaskExecutor(Executors.newFixedThreadPool(10));
-		return multicaster;
-	}
-	*/
+	 * @Bean
+	 * 
+	 * @Description("Application event multicaster to process events asynchonously"
+	 * ) public ApplicationEventMulticaster applicationEventMulticaster() {
+	 * SimpleApplicationEventMulticaster multicaster = new
+	 * SimpleApplicationEventMulticaster();
+	 * multicaster.setTaskExecutor(Executors.newFixedThreadPool(10)); return
+	 * multicaster; }
+	 */
 	@Bean
 	@Description("Tracks user presence (join / leave) and broacasts it to all connected users")
 	public PresenceEventListener presenceEventListener(SimpMessagingTemplate messagingTemplate) {
@@ -48,20 +47,20 @@ public class ChatConfig {
 		presence.setLogoutDestination(Destinations.LOGOUT);
 		return presence;
 	}
-	
-	@Bean 
+
+	@Bean
 	@Description("Keeps connected users")
 	public ParticipantRepository participantRepository() {
 		return new ParticipantRepository();
 	}
-	
+
 	@Bean
-	@Scope(value = "websocket", proxyMode =ScopedProxyMode.TARGET_CLASS)
+	@Scope(value = "websocket", proxyMode = ScopedProxyMode.TARGET_CLASS)
 	@Description("Keeps track of the level of profanity of a websocket session")
 	public SessionProfanity sessionProfanity() {
 		return new SessionProfanity(MAX_PROFANITY_LEVEL);
 	}
-	
+
 	@Bean
 	@Description("Utility class to check the number of profanities and filter them")
 	public ProfanityChecker profanityFilter() {

--- a/src/main/java/com/sergialmar/wschat/config/RedisConfig.java
+++ b/src/main/java/com/sergialmar/wschat/config/RedisConfig.java
@@ -8,44 +8,53 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 import redis.clients.jedis.Protocol;
 import redis.embedded.RedisServer;
 
+/**
+ * Redis is required for {@link EnableRedisHttpSession} handling.
+ */
 @Configuration
 public class RedisConfig {
 
 	@Bean
-    public static RedisServerBean redisServer() {
-        return new RedisServerBean();
-    }
+	public static RedisServerBean redisServer() {
+		return new RedisServerBean();
+	}
+	
+	/**
+	 * Implements BeanDefinitionRegistryPostProcessor to ensure this Bean is
+	 * initialized before any other Beans. Specifically, we want to ensure that
+	 * the Redis Server is started before RedisHttpSessionConfiguration attempts
+	 * to enable Keyspace notifications.
+	 */
+	static class RedisServerBean implements InitializingBean, DisposableBean, BeanDefinitionRegistryPostProcessor {
 
-    /**
-     * Implements BeanDefinitionRegistryPostProcessor to ensure this Bean
-     * is initialized before any other Beans. Specifically, we want to ensure
-     * that the Redis Server is started before RedisHttpSessionConfiguration
-     * attempts to enable Keyspace notifications.
-     */
-    static class RedisServerBean implements InitializingBean, DisposableBean, BeanDefinitionRegistryPostProcessor {
-        private RedisServer redisServer;
+		private RedisServer redisServer;
 
-        public void afterPropertiesSet() throws Exception {
-        	
-            redisServer = new RedisServer(Protocol.DEFAULT_PORT);
-            redisServer.start();
-        }
+		@Override
+		public void afterPropertiesSet() throws Exception {
 
-        public void destroy() throws Exception {
-            if(redisServer != null) {
-                redisServer.stop();
-            }
-        }
+			redisServer = new RedisServer(Protocol.DEFAULT_PORT);
+			redisServer.start();
+		}
 
-        @Override
-        public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {}
+		@Override
+		public void destroy() throws Exception {
+			if (redisServer != null) {
+				redisServer.stop();
+			}
+		}
 
-        @Override
-        public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {}
+		@Override
+		public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+		}
 
-    }
+		@Override
+		public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+		}
+
+	}
 }

--- a/src/main/java/com/sergialmar/wschat/config/WebSecurityConfig.java
+++ b/src/main/java/com/sergialmar/wschat/config/WebSecurityConfig.java
@@ -50,10 +50,12 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		
 		auth.authenticationProvider(new AuthenticationProvider() {
 			
+			@Override
 			public boolean supports(Class<?> authentication) {
 				return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
 			}
 			
+			@Override
 			public Authentication authenticate(Authentication authentication) throws AuthenticationException {
 				UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken) authentication;
 				

--- a/src/main/java/com/sergialmar/wschat/config/WebSocketConfig.java
+++ b/src/main/java/com/sergialmar/wschat/config/WebSocketConfig.java
@@ -11,6 +11,7 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 @EnableWebSocketMessageBroker
 public class WebSocketConfig extends AbstractSessionWebSocketMessageBrokerConfigurer<ExpiringSession> {
 	
+	@Override
 	protected void configureStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws").withSockJS();
 	}

--- a/src/main/java/com/sergialmar/wschat/config/WebSocketSecurityConfig.java
+++ b/src/main/java/com/sergialmar/wschat/config/WebSocketSecurityConfig.java
@@ -1,7 +1,6 @@
 package com.sergialmar.wschat.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.security.config.annotation.web.messaging.MessageSecurityMetadataSourceRegistry;
 import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
 
@@ -9,11 +8,17 @@ import org.springframework.security.config.annotation.web.socket.AbstractSecurit
 public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBrokerConfigurer {
 
 	@Override
-    protected void configureInbound(MessageSecurityMetadataSourceRegistry messages) {
-        messages
-        		.antMatchers(SimpMessageType.MESSAGE, "/topic/chat.login", 
-        											  "/topic/chat.logout", 
-        											  "/topic/chat.message").denyAll()
-                .anyMessage().authenticated();
-    }
+	protected void configureInbound(MessageSecurityMetadataSourceRegistry messages) {
+		messages
+		// .antMatchers(SimpMessageType.MESSAGE, "/topic/chat.login",
+		// "/topic/chat.logout",
+		// "/topic/chat.message").denyAll()
+				.anyMessage().authenticated();
+	}
+
+	@Override
+	protected boolean sameOriginDisabled() {
+		//disable CSRF for websockets for now...
+		return true;
+	}
 }

--- a/src/main/java/com/sergialmar/wschat/event/LoginEvent.java
+++ b/src/main/java/com/sergialmar/wschat/event/LoginEvent.java
@@ -7,9 +7,10 @@ import java.util.Date;
  * @author Sergi Almar
  */
 public class LoginEvent {
+
 	private String username;
 	private Date time;
-	
+
 	public LoginEvent(String username) {
 		this.username = username;
 		time = new Date();

--- a/src/main/java/com/sergialmar/wschat/event/LogoutEvent.java
+++ b/src/main/java/com/sergialmar/wschat/event/LogoutEvent.java
@@ -5,8 +5,9 @@ package com.sergialmar.wschat.event;
  * @author Sergi Almar
  */
 public class LogoutEvent {
-	private String username;
 	
+	private String username;
+
 	public LogoutEvent(String username) {
 		this.username = username;
 	}
@@ -18,5 +19,4 @@ public class LogoutEvent {
 	public void setUsername(String username) {
 		this.username = username;
 	}
-
 }

--- a/src/main/java/com/sergialmar/wschat/event/ParticipantRepository.java
+++ b/src/main/java/com/sergialmar/wschat/event/ParticipantRepository.java
@@ -8,8 +8,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Sergi Almar
  */
 public class ParticipantRepository {
-	private Map<String, LoginEvent> activeSessions = new ConcurrentHashMap<>(); 
-	
+
+	private Map<String, LoginEvent> activeSessions = new ConcurrentHashMap<>();
+
 	public void add(String sessionId, LoginEvent event) {
 		activeSessions.put(sessionId, event);
 	}
@@ -17,11 +18,11 @@ public class ParticipantRepository {
 	public LoginEvent getParticipant(String sessionId) {
 		return activeSessions.get(sessionId);
 	}
-	
+
 	public void removeParticipant(String sessionId) {
 		activeSessions.remove(sessionId);
 	}
-	
+
 	public Map<String, LoginEvent> getActiveSessions() {
 		return activeSessions;
 	}

--- a/src/main/java/com/sergialmar/wschat/event/PresenceEventListener.java
+++ b/src/main/java/com/sergialmar/wschat/event/PresenceEventListener.java
@@ -1,15 +1,12 @@
 package com.sergialmar.wschat.event;
 
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
-import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 /**
@@ -31,6 +28,7 @@ public class PresenceEventListener implements ApplicationListener<ApplicationEve
 		this.participantRepository = participantRepository;
 	}
 	
+	@Override
 	public void onApplicationEvent(ApplicationEvent event) {
 		
 		if(event instanceof SessionConnectEvent) {

--- a/src/main/java/com/sergialmar/wschat/exception/TooMuchProfanityException.java
+++ b/src/main/java/com/sergialmar/wschat/exception/TooMuchProfanityException.java
@@ -6,6 +6,8 @@ package com.sergialmar.wschat.exception;
  */
 public class TooMuchProfanityException extends RuntimeException {
 
+	private static final long serialVersionUID = 1L;
+
 	public TooMuchProfanityException(String message) {
 		super(message);
 	}

--- a/src/main/java/com/sergialmar/wschat/util/ProfanityChecker.java
+++ b/src/main/java/com/sergialmar/wschat/util/ProfanityChecker.java
@@ -13,16 +13,16 @@ import java.util.stream.Collectors;
 public class ProfanityChecker {
 
 	private Set<String> profanities = new HashSet<>();
-	
+
 	public long getMessageProfanity(String message) {
-		return Arrays.asList(message.split(" ")).stream()
-				.filter(word -> profanities.contains(word))
+		return Arrays.stream(message.split(" ")) //
+				.filter(word -> profanities.contains(word)) //
 				.count();
 	}
-	
+
 	public String filter(String message) {
-		return Arrays.asList(message.split(" ")).stream()
-				.filter(word -> !profanities.contains(word))
+		return Arrays.stream(message.split(" "))//
+				.filter(word -> !profanities.contains(word)) //
 				.collect(Collectors.joining(" "));
 	}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-logging.level.org.springframework: DEBUG
+#logging.level.org.springframework: DEBUG


### PR DESCRIPTION
Updated to latest Spring Boot version 1.2.4.RELEASE.
Updated to Spring Security 4.0.1.
Adapted WebSocketSecurity configuration to latest changes in Spring
Security 4.0.1, e.g. by explicitly the CSRF support for WS.

Some additional polishing:
General code formatting.
Added @Override annotations to get rid of some warnings.
Added serializationUID to TooMuchProfanityException. 
Disabled debug logging in application.properties
More idiomatic stream construction from arrays: Changed Arrays.asList(array).stream() to Arrays.stream(array) in ProfanityChecker.
